### PR TITLE
Allow configuration from Django without .json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,25 @@ FIREBASE_AUTH = {
 }
 ```
 
+Alternatively, you can configure the Firebase credentials directly, like so:
+
+```
+FIREBASE_AUTH = {
+    'FIREBASE_CREDENTIALS': {
+        'type': "service_account",
+        'project_id': "",
+        'private_key_id': "",
+        'private_key': "",
+        'client_email': "",
+        'client_id': "",
+        'auth_uri': "https://accounts.google.com/o/oauth2/auth",
+        'token_uri': "https://accounts.google.com/o/oauth2/token",
+        'auth_provider_x509_cert_url': "https://www.googleapis.com/oauth2/v1/certs",
+        'client_x509_cert_url': ""
+    }
+}
+```
+
 ## Publishing
 
 `python setup.py sdist`

--- a/rest_framework_firebase/__init__.py
+++ b/rest_framework_firebase/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'djangorestframework-firebase-auth'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __author__ = 'Wesley Lima'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2018 Fan Retreat, Inc.'

--- a/rest_framework_firebase/__init__.py
+++ b/rest_framework_firebase/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'djangorestframework-firebase-auth'
-__version__ = '0.1.4'
+__version__ = '0.2.0'
 __author__ = 'Wesley Lima'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2018 Fan Retreat, Inc.'

--- a/rest_framework_firebase/authentication.py
+++ b/rest_framework_firebase/authentication.py
@@ -12,9 +12,13 @@ from rest_framework.authentication import (
     BaseAuthentication, get_authorization_header
 )
 
-# TODO: Support entering the keys individually later
-cred = credentials.Certificate(api_settings.FIREBASE_ACCOUNT_KEY_FILE)
-firebase = firebase_admin.initialize_app(cred)
+if api_settings.FIREBASE_ACCOUNT_KEY_FILE:
+    creds = credentials.Certificate(api_settings.FIREBASE_ACCOUNT_KEY_FILE)
+else:
+    creds = credentials.Certificate(api_settings.FIREBASE_CREDENTIALS)
+
+firebase = firebase_admin.initialize_app(creds)
+
 
 class BaseFirebaseAuthentication(BaseAuthentication):
     """

--- a/rest_framework_firebase/settings.py
+++ b/rest_framework_firebase/settings.py
@@ -8,11 +8,19 @@ USER_SETTINGS = getattr(settings, 'FIREBASE_AUTH', None)
 
 DEFAULTS = {
     'FIREBASE_ACCOUNT_KEY_FILE': '', # JSON formatted key file you get directly from firebase
-
-    # The credentials if you want to enter them in manually (not implemented)
-    'FIREBASE_PRIVATE_KEY': None,
-    'FIREBASE_PUBLIC_KEY': None,
-    'FIREBASE_CLIENT_EMAIL': None,
+    'FIREBASE_CREDENTIALS': {
+        'type': "service_account",
+        'project_id': "",
+        'private_key_id': "",
+        'private_key': "",
+        'client_email': "",
+        'client_id': "",
+        'auth_uri': "https://accounts.google.com/o/oauth2/auth",
+        'token_uri': "https://accounts.google.com/o/oauth2/token",
+        'auth_provider_x509_cert_url': "https://www.googleapis.com/oauth2/v1/certs",
+        'client_x509_cert_url': ""
+    }, # the credentials in raw json form
+    
     'FIREBASE_CREATE_NEW_USER': True, # We'll make a new user if we get one that we don't have yet
 
     'FIREBASE_AUTH_HEADER_PREFIX': "JWT",


### PR DESCRIPTION
Hello,

I have added `FIREBASE_CREDENTIALS` as a config variable so that you can pass the config in via Django. I saw that you had this as a TODO so thought I'd contribute it.

Use case: Heroku does secrets as environment variables, ideally I want to populate the Firebase config using calls to `os.getenv()` in `settings.py` rather than by creating a non-git tracked file.

Thanks,

Patrick
