### PR TITLE
Support default configuration

### DIFF
--- a/rest_framework_firebase/authentication.py
+++ b/rest_framework_firebase/authentication.py
@@ -14,9 +14,10 @@ from rest_framework.authentication import (
 
 if api_settings.FIREBASE_ACCOUNT_KEY_FILE:
     creds = credentials.Certificate(api_settings.FIREBASE_ACCOUNT_KEY_FILE)
-else:
+elif api_settings.FIREBASE_CREDENTIALS:
     creds = credentials.Certificate(api_settings.FIREBASE_CREDENTIALS)
-
+else:
+    creds = None
 firebase = firebase_admin.initialize_app(creds)
 
 


### PR DESCRIPTION
I am planning to use this middleware on our GAE standard v2 app.

According the following document, when `firebase_admin.initialize_app` is passed with no credentials, it configures itself appropriately with Application Default Credentials. GAE standard v2 supports this Application Default Credentials.

https://firebase.google.com/docs/reference/admin/python/firebase_admin#initialize_app

So, I've added an alternative configuration for without any credentials.